### PR TITLE
Manage the syslog-ng repo

### DIFF
--- a/.fixtures-old.yml
+++ b/.fixtures-old.yml
@@ -1,5 +1,7 @@
 fixtures:
   repositories:
+     apt: 'https://github.com/puppetlabs/puppetlabs-apt.git'
+     translate: 'https://github.com/puppetlabs/puppetlabs-translate.git'
      stdlib:
        repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
        ref: 4.5.0

--- a/.fixtures-old.yml
+++ b/.fixtures-old.yml
@@ -4,7 +4,7 @@ fixtures:
      translate: 'https://github.com/puppetlabs/puppetlabs-translate.git'
      stdlib:
        repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-       ref: 4.5.0
+       ref: 4.6.0
      concat:
        repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
        ref: 2.0.0

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,11 @@
 fixtures:
   repositories:
-    stdlib: 
-      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-    concat:
-      repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'
+    apt: 'https://github.com/puppetlabs/puppetlabs-apt.git'
+    concat: 'https://github.com/puppetlabs/puppetlabs-concat.git'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    translate: 'https://github.com/puppetlabs/puppetlabs-translate.git'
+    yumrepo_core:
+      repo: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core.git'
+      puppet_version: '>= 6.0.0'
 #  symlinks:
 #    "syslog_ng": "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ to install the module:
  ```
 
 ### What syslog_ng affects
+* It setup a repository with recent syslog-ng releases (only on RedHat and
+  Debian based operating systems and if `$syslog_ng::manage_repo` is set to
+  `true`)
 * It installs the `syslog-ng` or `syslog-ng-core` package
   * that creates the necessary directories on your system, including `/etc/syslog-ng`.
   * If another `syslog` daemon is installed, it will be removed by your package manager.
@@ -171,6 +174,8 @@ with default configuration on your system.
 ##### `config_file`
 Configures the path of the configuration file. Defaults to `/etc/syslog-ng/syslog-ng.conf` on
 all operation systems.
+##### `manage_repo`
+Controls if the module is managing the unofficial repositories of syslog-ng packages.  Use `true` if you want to use the latest version of syslog-ng from the [unofficial Debian repository](https://www.syslog-ng.com/community/b/blog/posts/installing-the-latest-syslog-ng-on-ubuntu-and-other-deb-distributions) or [unofficial RedHat repository](https://www.syslog-ng.com/community/b/blog/posts/installing-latest-syslog-ng-on-rhel-and-other-rpm-distributions).  Defaults to `false`.
 ##### `manage_package`
 Controls if the module is managing the package resource or not. Use `false` if you are already handling this in your manifests. Defaults to `true`
 ##### `manage_init_defaults`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class syslog_ng (
   $config_file_header,
   $package_ensure,
   $manage_init_defaults = false,
+  $manage_repo          = false,
   $manage_package       = true,
   $modules              = [],
   $sbin_path            = '/usr/sbin',
@@ -25,6 +26,8 @@ class syslog_ng (
   validate_hash($init_config_hash)
 
   if ($manage_package) {
+    include syslog_ng::repo
+
     package { $package_name:
       ensure => $package_ensure,
       before => [

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,0 +1,43 @@
+class syslog_ng::repo {
+  if $syslog_ng::manage_repo {
+    $major_release = $facts['os']['release']['major']
+
+    case $facts['os']['family'] {
+      'Redhat', 'Amazon': {
+        yumrepo { 'czanik-syslog-ng-githead':
+          ensure   => present,
+          name     => 'czanik-syslog-ng-githead',
+          descr    => 'Copr repo for syslog-ng-githead owned by czanik',
+          baseurl  => "https://copr-be.cloud.fedoraproject.org/results/czanik/syslog-ng-githead/epel-${major_release}-\$basearch/",
+          gpgkey   => 'https://copr-be.cloud.fedoraproject.org/results/czanik/syslog-ng-githead/pubkey.gpg',
+          enabled  => '1',
+          gpgcheck => '1',
+          target   => '',
+          before   => Package[$syslog_ng::package_name],
+        }
+      }
+      'Debian': {
+        $release_url = $facts['os']['name'] ? {
+          'Debian' => "http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/Debian_${major_release}.0",
+          'Ubuntu' => "http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_${major_release}",
+        }
+
+        apt::source { 'syslog-ng-obs':
+          comment  => 'syslog-ng unofficial repository, https://www.syslog-ng.com/community/b/blog/posts/installing-the-latest-syslog-ng-on-ubuntu-and-other-deb-distributions',
+          location => $release_url,
+          release  => '',
+          repos    => './',
+          key      => {
+            id     => 'F20F51628D04901AD01175013B92A8D27CFDAEDD',
+            source => "${release_url}/Release.key",
+          },
+          include  => {
+            deb => true,
+            src => false,
+          },
+          before   => Package[$syslog_ng::package_name],
+        }
+      }
+    }
+  }
+}

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -35,8 +35,9 @@ class syslog_ng::repo {
             deb => true,
             src => false,
           },
-          before   => Package[$syslog_ng::package_name],
         }
+
+        Class['apt::update'] -> Package <| tag == 'syslog_ng' |>
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 4.6.0"
     },
     {
       "name": "puppetlabs/concat",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,7 +4,7 @@ describe 'syslog_ng' do
 
   let(:facts)  {{ concat_basedir: '/dne',
                   osfamily: 'Debian',
-                  os: { family: 'Debian' },
+                  os: { family: 'Debian', name: 'Ubuntu', release: { full: '14.04', major: '14.04' } },
                   operatingsystem: 'Ubuntu'
   }}
 
@@ -22,22 +22,48 @@ describe 'syslog_ng' do
       should contain_file('/etc/default/syslog-ng')
     }
   end
-  context 'On RedHat with init_defaults set to true' do
-    let(:params) {{
-      :manage_init_defaults => true
-    }}
+
+  context 'with unofficial repo' do
+    let(:params) do
+      {
+        manage_repo: true,
+      }
+    end
+
+    it { should compile }
+    it { should contain_apt__source('syslog-ng-obs') }
+  end
+
+  context 'On RedHat' do
     let(:facts)  {{ concat_basedir: '/dne',
                     osfamily: 'RedHat',
-                    os: { family: 'RedHat' },
+                    os: { family: 'RedHat', name: 'RedHat', release: { major: '7' } },
                     operatingsystem: 'RedHat'
     }}
-    it {
-      should contain_package('syslog-ng')
-      should contain_service('syslog-ng')
-    }
-    it {
-      should contain_file('/etc/sysconfig/syslog-ng')
-    }
+
+    context 'with init_defaults set to true' do
+      let(:params) {{
+        :manage_init_defaults => true
+      }}
+      it {
+        should contain_package('syslog-ng')
+        should contain_service('syslog-ng')
+      }
+      it {
+        should contain_file('/etc/sysconfig/syslog-ng')
+      }
+    end
+
+    context 'with unofficial repo' do
+      let(:params) do
+        {
+          manage_repo: true,
+        }
+      end
+
+      it { should compile }
+      it { should contain_yumrepo('czanik-syslog-ng-githead') }
+    end
   end
   context 'On SLES with init_defaults set to true' do
     let(:params) {{

--- a/spec/defines/module_spec.rb
+++ b/spec/defines/module_spec.rb
@@ -9,7 +9,7 @@ describe 'syslog_ng::module', :type => 'define' do
   } end
   let :facts do
      default_facts.merge(
-       { osfamily: 'Debian', os: { family: 'Debian' } }
+       { osfamily: 'Debian', os: { family: 'Debian', name: 'Ubuntu', release: { full: '14.4', major: '14.4' } } }
      )
   end
   context "When overriding module_prefix" do
@@ -22,7 +22,7 @@ describe 'syslog_ng::module', :type => 'define' do
   context "When osfamily is RedHat" do
     let :facts do
       default_facts.merge(
-        { osfamily: 'RedHat', os: { family: 'RedHat' } }
+        { osfamily: 'RedHat', os: { family: 'RedHat', release: { major: '7' } } }
       )
     end
     let :pre_condition do

--- a/spec/defines/statement.rb
+++ b/spec/defines/statement.rb
@@ -1,7 +1,7 @@
 shared_examples_for "Statement" do |id, type|
     let(:facts)  { { concat_basedir: '/dne',
                     osfamily: 'Debian',
-                    os: { family: 'Debian' },
+                    os: { family: 'Debian', name: 'Ubuntu', release: { full: '14.04', major: '14.04' } },
                     operatingsystem: 'Ubuntu' } }
 
     let(:pre_condition) { 'include syslog_ng' }


### PR DESCRIPTION
Fresh packages are available for Debian and RedHat based systems.  Add
support for these external repositories and make it possible to skip
using them.