### PR TITLE
Normalize syslog_ng_version

### DIFF
--- a/lib/facter/syslog_ng_semantic_version.rb
+++ b/lib/facter/syslog_ng_semantic_version.rb
@@ -1,0 +1,6 @@
+Facter.add(:syslog_ng_semantic_version) do
+  setcode do
+    Facter.value(:syslog_ng_version) =~ /^(\d+\.\d+\.\d+)/
+    $1
+  end
+end


### PR DESCRIPTION
The package information as reported by the "Installer-Version" key in the `syslog-ng --version` output depends on compilation flags, as as so is currently reported as:

 * `3.22.1` on an Ubuntu based system;
 * `3.22.1.15.g3cf9ae3` on a CentOS 7 system.

This change normalize the `syslog_ng_version` flag to always match the x.y.z format.