### PR TITLE
Remove notice messages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,8 +50,6 @@ class syslog_ng (
     syntax_check_before_reloads => $syntax_check_before_reloads,
   }
 
-  notice("config_file: ${config_file}")
-
   concat::fragment { 'syslog_ng header':
     target  => $config_file,
     content => $config_file_header,

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -12,8 +12,6 @@ class syslog_ng::reload (
 
   $syslog_ng_syntax_check_cmd = "${syslog_ng_full_path} --syntax-only --cfgfile %"
 
-  notice("syslog_ng::reload: syntax_check_before_reloads=${syntax_check_before_reloads}")
-
   exec { 'syslog_ng_reload':
     command     => "${syslog_ng_ctl_full_path} reload",
     path        => $exec_path,


### PR DESCRIPTION
I am currently fighting with the various modules that produce messages in my PuppetServer logs.  These messages seems to be debug ones and do not denote something to be changed in the configuration.  They can be either dropped (what I propose here) or be converted to debug messages to not be logged by default.

Currently, using notice(), they are emitted at the info priority and are therefore stored in the PuppetServer log.