### PR TITLE
Drop support for OS which have reached EOL

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,9 +21,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "5.0",
-        "6.0",
-        "7.0",
         "8.0",
         "9.0"
       ]
@@ -31,10 +28,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
-        "14.04",
-        "12.04",
-        "10.04"
+        "16.04"
       ]
     },
     {


### PR DESCRIPTION
The oldest supported Debian release is 8.0.  Likewise, any version of
Ubuntu older than 16.04 has reached EOL.

Remove them from the list of supported operating systems.