### PR TITLE
Set upper bounds for dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0"
+      "version_requirement": ">= 4.6.0 <= 9.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.0"
+      "version_requirement": ">= 1.2.0 <= 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This is commonly done in puppet modules and might help tracking
dependencies on updates.
