### PR TITLE
Fix acceptance tests of expected to fail tests

### DIFF
--- a/examples/NOK_wrong_version.pp
+++ b/examples/NOK_wrong_version.pp
@@ -1,0 +1,16 @@
+class { 'syslog_ng':
+  config_file                 => '/tmp/syslog-ng.conf',
+  manage_package              => false,
+  syntax_check_before_reloads => true,
+  user                        => 'balabit',
+  group                       => 'balabit',
+  manage_init_defaults        => false,
+}
+
+# Should fail with:
+#    Error parsing config, syntax error, unexpected LL_ERROR, expecting end of file
+
+syslog_ng::config { 'version':
+  content => '@version 3.6',
+  order   => '02',
+}

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -40,7 +40,9 @@ describe 'syslog_ng class' do
   Dir[File.join(__dir__, '..', '..', 'examples', 'NOK_*.pp')].each do |f|
     example = File.basename(f)
     context "Example #{example}" do
-      it { is_expected.to compile.and_raise_error }
+      it 'applies with errors' do
+        apply_manifest(File.read(f), expect_failures: true)
+      end
     end
   end
 end


### PR DESCRIPTION
We don't have any ATM, but if they arrive this should rather work.

This code was not tested when it was introduced because there are only OK tests in this repo, but when the code was copied to the patterndb module, it proved to be wrong.  Import the fix from patterndb to this module.
