### PR TITLE
Drop CentOS 7 and 8 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,8 +27,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8"
       ]
     },
     {


### PR DESCRIPTION
These versions or CentOS have reached end-of-life and the images used
for CI are not available anymore.  As we cannot ensure these legacy
systems are still working with the module, remove them from
metadata.json.

~~Also include:~~
  * ~~#45~~