### PR TITLE
Improve defaults file management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,7 +87,6 @@ class syslog_ng (
   }
 
   if $manage_init_defaults {
-    $merged_init_config_hash = merge($init_config_hash,$init_config_hash)
     file { $init_config_file:
       ensure  => file,
       content => template('syslog_ng/init_config_file.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class syslog_ng (
   if $manage_init_defaults {
     file { $init_config_file:
       ensure  => file,
-      content => template('syslog_ng/init_config_file.erb'),
+      content => epp('syslog_ng/init_config_file.epp'),
       notify  => Service[$service_name],
     }
   }

--- a/templates/init_config_file.epp
+++ b/templates/init_config_file.epp
@@ -11,6 +11,6 @@
 # Command line options to syslog-ng
 #SYSLOGNG_OPTS="--no-caps"
 #SYSLOGNG_OPTS="-f /usr/local/etc/syslog-ng.conf"
-<% @init_config_hash.sort.map do |k,v| -%>
-<%=k%>=<%=v%>
-<% end -%>
+<% $syslog_ng::init_config_hash.each |$k, $v| { -%>
+<%= $k %>=<%= $v %>
+<% } -%>

--- a/templates/init_config_file.epp
+++ b/templates/init_config_file.epp
@@ -12,5 +12,5 @@
 #SYSLOGNG_OPTS="--no-caps"
 #SYSLOGNG_OPTS="-f /usr/local/etc/syslog-ng.conf"
 <% $syslog_ng::init_config_hash.each |$k, $v| { -%>
-<%= $k %>=<%= $v %>
+<%= $k %>=<%= $v.shellquote %>
 <% } -%>

--- a/templates/init_config_file.erb
+++ b/templates/init_config_file.erb
@@ -11,6 +11,6 @@
 # Command line options to syslog-ng
 #SYSLOGNG_OPTS="--no-caps"
 #SYSLOGNG_OPTS="-f /usr/local/etc/syslog-ng.conf"
-<% @merged_init_config_hash.sort.map do |k,v| -%>
+<% @init_config_hash.sort.map do |k,v| -%>
 <%=k%>=<%=v%>
 <% end -%>


### PR DESCRIPTION
I spotted a few inconsistencies while tweaking my config with:

```puppet
  class { 'syslog_ng':
    # ...
    manage_init_defaults => true,
    init_config_hash     => {
      'SYSLOGNG_OPTS' => "--caps 'cap_net_bind_service,cap_net_broadcast,cap_net_raw,cap_dac_read_search,cap_dac_override,cap_chown,cap_fowner=p cap_syslog=ep cap_dac_read_search+e'",
    },
  }
```

This PR fix them.